### PR TITLE
UTF-8 encoding for setup (Issue #29)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 import setuptools
 
-with open(r'README.md', mode=r'r') as readme_handle:
+with open(r'README.md', mode=r'r', encoding="utf8") as readme_handle:
     long_description = readme_handle.read()
 
 setuptools.setup(


### PR DESCRIPTION
the symbol “ caused problems when trying to pip install the library on windows (Issue #29)
adding the UTF-8 encoding when reading the README.md per default fixes this issue